### PR TITLE
don't create a duplicate entry in the database for the same User

### DIFF
--- a/O365-APIs-Start-ASPNET-MVC/Models/ADALTokenCache.cs
+++ b/O365-APIs-Start-ASPNET-MVC/Models/ADALTokenCache.cs
@@ -70,12 +70,16 @@ namespace O365_APIs_Start_ASPNET_MVC.Models
             // if state changed
             if (this.HasStateChanged)
             {
-                Cache = new UserTokenCache
+                if (Cache == null)
                 {
-                    webUserUniqueId = User,
-                    cacheBits = this.Serialize(),
-                    LastWrite = DateTime.Now
-                };
+                    Cache = new UserTokenCache
+                    {
+                        webUserUniqueId = User
+                    };
+                }
+                Cache.cacheBits = this.Serialize();
+                Cache.LastWrite = DateTime.Now;
+
                 //// update the DB and the lastwrite                
                 db.Entry(Cache).State = Cache.UserTokenCacheId == 0 ? EntityState.Added : EntityState.Modified;
                 db.SaveChanges();


### PR DESCRIPTION
The implementation of AfterAccessNotification would create a new entry in the session state database for the same webUserUniqueId resulting in problems when other methods retrieve the session state with FirstOrDefault.
The change simply checks whether to create a new item or update the existing one before storing in the database.
